### PR TITLE
Fix compile errors for Lazarus 4.99

### DIFF
--- a/SynFacilBasic.pas
+++ b/SynFacilBasic.pas
@@ -1607,18 +1607,18 @@ begin
      if tFrameCol.hay then Atrib.FrameColor:=tFrameCol.col;
      if tFrameEdg.hay then begin
        case UpCase(tFrameEdg.val) of
-       'AROUND':Atrib.FrameEdges:=sfeAround;
-       'BOTTOM':Atrib.FrameEdges:=sfeBottom;
-       'LEFT':  Atrib.FrameEdges:=sfeLeft;
-       'NONE':  Atrib.FrameEdges:=sfeNone;
+       'AROUND':Atrib.FrameEdges:=TSynFrameEdges.sfeAround;
+       'BOTTOM':Atrib.FrameEdges:=TSynFrameEdges.sfeBottom;
+       'LEFT':  Atrib.FrameEdges:=TSynFrameEdges.sfeLeft;
+       'NONE':  Atrib.FrameEdges:=TSynFrameEdges.sfeNone;
        end;
      end;
      if tFrameSty.hay then begin
        case UpCase(tFrameSty.val) of
-       'SOLID': Atrib.FrameStyle:=slsSolid;
-       'DASHED':Atrib.FrameStyle:=slsDashed;
-       'DOTTED':Atrib.FrameStyle:=slsDotted;
-       'WAVED': Atrib.FrameStyle:=slsWaved;
+       'SOLID': Atrib.FrameStyle:=TSynLineStyle.slsSolid;
+       'DASHED':Atrib.FrameStyle:=TSynLineStyle.slsDashed;
+       'DOTTED':Atrib.FrameStyle:=TSynLineStyle.slsDotted;
+       'WAVED': Atrib.FrameStyle:=TSynLineStyle.slsWaved;
        end;
      end;
      if tStyBold.hay then begin  //negrita

--- a/SynFacilBasic.pas
+++ b/SynFacilBasic.pas
@@ -1521,7 +1521,7 @@ begin
   //También lo puede buscar en Attrib[]
   for i:=0 to AttrCount-1 do begin
     if Upcase(Attribute[i].Name) = txt then begin
-        Result := Attribute[i];  //devuelve índice
+        Result := Attribute[i] as TSynHighlighterAttributes;  //devuelve índice
         exit;
     end;
   end;

--- a/SynFacilBasic.pas
+++ b/SynFacilBasic.pas
@@ -1520,7 +1520,7 @@ begin
   txt := UpCase(txt);   //ignora la caja
   //También lo puede buscar en Attrib[]
   for i:=0 to AttrCount-1 do begin
-    if Upcase(Attribute[i].Name) = txt then begin
+    if Upcase(Attribute[i].Caption^) = txt then begin
         Result := Attribute[i] as TSynHighlighterAttributes;  //devuelve índice
         exit;
     end;
@@ -1537,7 +1537,7 @@ begin
   txt := UpCase(txt);   //ignora la caja
   //Se tiene que buscar en Attrib[], proque allí están con los índices cprrectos
   for i:=0 to AttrCount-1 do begin
-    if Upcase(Attrib[i].Name) = txt then begin
+    if Upcase(Attrib[i].Caption^) = txt then begin
         Result := i;  //devuelve índice
         exit;
     end;


### PR DESCRIPTION
Some stuff has been moved to `LazEditTextAttributes` unit. These changes address the incompatibilities (and should still work on 3.8 to 4.2).